### PR TITLE
fix(auth.service): prevent crash when failing to fetch oidc info on boot

### DIFF
--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,10 +1,16 @@
-import { Injectable, Inject, BadRequestException } from '@nestjs/common';
+import {
+  Injectable,
+  Inject,
+  OnModuleInit,
+  Logger,
+  ServiceUnavailableException,
+} from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
+import { SecretOrKeyProvider } from 'passport-jwt';
 import { lastValueFrom } from 'rxjs';
 import * as jsonwebtoken from 'jsonwebtoken';
 import { JwksClient } from 'jwks-rsa';
 import * as jexl from 'jexl';
-
 import { JWT_MAPPER, OIDC_AUTHORITY, ROLE_EVALUATORS } from '../consts';
 import { RoleEvaluator } from '../interfaces';
 
@@ -13,16 +19,11 @@ const mapValue = (obj: any) => (obj ? obj.map((value) => ({ value })) : []);
 jexl.addTransform('length', length);
 jexl.addTransform('mapValue', mapValue);
 
-type SecretOrKeyProviderCallback = (error, secret: false | string) => void;
-type SecretOrKeyProvider = (
-  request,
-  rawJwtToken,
-  done: SecretOrKeyProviderCallback,
-) => void;
 @Injectable()
-export class AuthService {
-  private _oidcConfig: any | null = null;
-  private jwksClient: Promise<JwksClient>;
+export class AuthService implements OnModuleInit {
+  private readonly logger = new Logger(AuthService.name);
+  private _oidcConfig: Promise<any> | undefined;
+  private _jwksClient: Promise<JwksClient> | undefined;
 
   constructor(
     @Inject(ROLE_EVALUATORS)
@@ -32,42 +33,44 @@ export class AuthService {
     @Inject(JWT_MAPPER)
     protected readonly jwtMapper: (payload: any) => any,
     protected readonly httpService: HttpService,
-  ) {
-    this.jwksClient = this.getJwksClient();
-  }
+  ) {}
 
-  async getJwksClient(): Promise<JwksClient> {
-    const { jwks_uri } = await this.oidcConfig();
-    return new JwksClient({
-      jwksUri: jwks_uri,
+  onModuleInit() {
+    // attempt to eagerly load the jwksClient
+    this.getJwksClient().catch((err) => {
+      this.logger.warn(`Failed to load JWKS client on init: ${err}`);
     });
   }
 
-  async oidcConfig(): Promise<any> {
-    if (this._oidcConfig) return this._oidcConfig;
-
-    try {
-      const source$ = this.httpService.get(
-        `${this.oidcAuthority}/.well-known/openid-configuration`,
-      );
-      const response = await lastValueFrom(source$);
-      this._oidcConfig = response.data;
-      return this._oidcConfig;
-    } catch (err) {
-      throw new BadRequestException(
-        'There was an error when attempting to fetch openid-configuration',
-        { cause: err },
-      );
+  async getJwksClient(): Promise<JwksClient> {
+    if (!this._jwksClient) {
+      this._jwksClient = this.loadJwksClient().catch((err) => {
+        // allow retry by clearing the cached promise
+        this._jwksClient = undefined;
+        throw err;
+      });
     }
+    return await this._jwksClient;
   }
 
-  async getPublicKey(rawJwtToken): Promise<string> {
+  async oidcConfig(): Promise<any> {
+    if (!this._oidcConfig) {
+      this._oidcConfig = this.loadOidcConfig().catch((err) => {
+        // allow retry by clearing the cached promise
+        this._oidcConfig = undefined;
+        throw err;
+      });
+    }
+    return await this._oidcConfig;
+  }
+
+  async getPublicKey(rawJwtToken: string): Promise<string> {
     const result = jsonwebtoken.decode(rawJwtToken, { complete: true });
 
     if (result && typeof result !== 'string' && result.header) {
       const { header } = result;
       const kid = header.kid;
-      const client = await this.jwksClient;
+      const client = await this.getJwksClient();
       const key = await client.getSigningKey(kid);
       return key.getPublicKey();
     }
@@ -82,6 +85,8 @@ export class AuthService {
           done(null, key);
         })
         .catch((error) => {
+          this.logger.error(`Error fetching public key: ${error}`);
+          // @ts-ignore (types don't match documentation)
           done(error, false);
         });
     };
@@ -110,5 +115,28 @@ export class AuthService {
     }
 
     return user;
+  }
+
+  private async loadJwksClient(): Promise<JwksClient> {
+    const { jwks_uri } = await this.oidcConfig();
+    return new JwksClient({
+      jwksUri: jwks_uri,
+    });
+  }
+
+  private async loadOidcConfig(): Promise<any> {
+    try {
+      const source$ = this.httpService.get(
+        `${this.oidcAuthority}/.well-known/openid-configuration`,
+      );
+      const response = await lastValueFrom(source$);
+      return response.data;
+    } catch (err) {
+      // this only bubbles up to the keyProvider error log
+      throw new ServiceUnavailableException(
+        `Failed to fetch openid-configuration: ${err}`,
+        { cause: err },
+      );
+    }
   }
 }


### PR DESCRIPTION
While the identity provider is down, auth will fail but will retry fetching the oidc info and public key.